### PR TITLE
bugfixed requireindex loading rules

### DIFF
--- a/plugin/templates/_plugin.js
+++ b/plugin/templates/_plugin.js
@@ -18,7 +18,7 @@ var requireIndex = require("requireindex");
 
 <% if (hasRules) { %>
 // import all rules in lib/rules
-module.exports.rules = requireIndex("./rules");
+module.exports.rules = requireIndex(__dirname + "/rules");
 <% } %>
 
 <% if (hasProcessors) { %>


### PR DESCRIPTION
Hi.

I got following error when writing a new plugin. I fixed loading rules with [requireindex npm](https://www.npmjs.com/package/requireindex#usage) at `lib/index.js` in plugin-template.
```
fs.js:857
  return binding.readdir(pathModule._makeLong(path));
                 ^

Error: ENOENT: no such file or directory, scandir './rules'
    at Error (native)
    at Object.fs.readdirSync (fs.js:857:18)
    at module.exports (/Users/sho/src/nodejs/eslint/eslint-plugin-if-in-test/node_modules/requireindex/index.js:18:20)
    at Object.<anonymous> (/Users/sho/src/nodejs/eslint/eslint-plugin-if-in-test/lib/index.js:11:24)
    at Module._compile (module.js:399:26)
    at Object.Module._extensions..js (module.js:406:10)
    at Module.load (module.js:345:32)
    at Function.Module._load (module.js:302:12)
    at Module.require (module.js:355:17)
    at require (internal/module.js:13:17)
```