### PR TITLE
Fix: npm test script on plugin generator

### DIFF
--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -10,7 +10,7 @@
   "author": "<%= userName %>",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha tests --recursive"
   },
   "dependencies": {
     "requireindex": "~1.1.0"


### PR DESCRIPTION
Generating a plugin, `yo eslint:plugin`, and then generating a rule, `yo eslint:rule`, would result in false-positive passing test suite, because the `npm test` script of `mocha` would not run any tests.

This changes the script from `mocha` to `mocha tests --recursive` to run any tests in the `tests` directory.

Fixes #25 