### PR TITLE
Make yo eslint:rule respect .editorconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "release": "eslint-release"
   },
   "dependencies": {
-    "yeoman-generator": "~0.16.0"
+    "editorconfig": "^0.13.2",
+    "gulp-beautify": "^2.0.0",
+    "gulp-filter": "^4.0.0",
+    "yeoman-generator": "~0.18.0"
   },
   "devDependencies": {
     "eslint-release": "^0.3.0",

--- a/rule/index.js
+++ b/rule/index.js
@@ -11,6 +11,9 @@
 var util = require("util");
 var path = require("path");
 var yeoman = require("yeoman-generator");
+var editorconfig = require("editorconfig");
+var beautify = require("gulp-beautify");
+var filter = require("gulp-filter");
 var validators = require("../lib/validators");
 
 //------------------------------------------------------------------------------
@@ -25,7 +28,14 @@ var isRequired = validators.isRequired;
 //------------------------------------------------------------------------------
 
 var ESLintRuleGenerator = module.exports = function ESLintRuleGenerator(args, options, config) {
-	yeoman.generators.Base.apply(this, arguments);
+    yeoman.generators.Base.apply(this, arguments);
+
+    var config = editorconfig.parseSync(path.join(process.cwd(), '*.js'));
+    var javascript = filter('**/*.js', {restore: true});
+
+    this.registerTransformStream(javascript);
+    this.registerTransformStream(beautify(config));
+    this.registerTransformStream(javascript.restore);
 };
 
 util.inherits(ESLintRuleGenerator, yeoman.generators.Base);


### PR DESCRIPTION
With this change all JavaScript files generated will go through a transform that modifies them to conform to the settings specified in .editorconfig, if it exists.

I know I didn't really give time for the feature request in #22 to be triaged, but I was going to make this change anyway to enable what I'm working on, so I figured I'd PR it.

Fixes #22