### PR TITLE
Upgrade: Update dependencies, fix deprecation warnings (fixes #17)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
-  - '0.10'
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "5"
 before_install:
   - currentfolder=${PWD##*/}
   - if [ "$currentfolder" != 'generator-eslint' ]; then cd .. && eval "mv $currentfolder generator-eslint" && cd generator-eslint; fi
-

--- a/package.json
+++ b/package.json
@@ -28,13 +28,16 @@
     "release": "eslint-release"
   },
   "dependencies": {
-    "yeoman-generator": "~0.16.0"
+    "mkdirp": "^0.5.1",
+    "yeoman-generator": "^0.22.5"
   },
   "devDependencies": {
     "eslint": "^2.6.0",
     "eslint-config-eslint": "^3.0.0",
-    "eslint-release": "^0.3.0",
-    "mocha": "~1.14.0"
+    "eslint-release": "^0.5.0",
+    "mocha": "^2.4.5",
+    "yeoman-assert": "^2.1.2",
+    "yeoman-test": "^1.1.0"
   },
   "peerDependencies": {
     "yo": ">=1.0.0"

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -9,6 +9,7 @@
 //------------------------------------------------------------------------------
 
 var util = require("util");
+var mkdirp = require("mkdirp");
 var yeoman = require("yeoman-generator");
 
 var validators = require("../lib/validators");
@@ -24,10 +25,10 @@ var isRequired = validators.isRequired;
 //------------------------------------------------------------------------------
 
 var ESLintPluginGenerator = module.exports = function ESLintPluginGenerator() {
-    yeoman.generators.Base.apply(this, arguments);
+    yeoman.Base.apply(this, arguments);
 };
 
-util.inherits(ESLintPluginGenerator, yeoman.generators.Base);
+util.inherits(ESLintPluginGenerator, yeoman.Base);
 
 ESLintPluginGenerator.prototype.askFor = function askFor() {
     var cb = this.async();
@@ -69,27 +70,23 @@ ESLintPluginGenerator.prototype.askFor = function askFor() {
         cb();
 
     }.bind(this));
-
-
 };
 
 ESLintPluginGenerator.prototype.generate = function generate() {
-
-    this.mkdir("lib");
-    this.mkdir("tests");
-    this.mkdir("tests/lib");
+    mkdirp.sync("lib");
+    mkdirp.sync("tests");
+    mkdirp.sync("tests/lib");
     this.template("_plugin.js", "lib/index.js");
     this.template("_package.json", "package.json");
     this.template("_README.md", "README.md");
 
     if (this.hasRules) {
-        this.mkdir("lib/rules");
-        this.mkdir("tests/lib/rules");
+        mkdirp.sync("lib/rules");
+        mkdirp.sync("tests/lib/rules");
     }
 
     if (this.hasProcessors) {
-        this.mkdir("lib/processors");
-        this.mkdir("tests/lib/processors");
+        mkdirp.sync("lib/processors");
+        mkdirp.sync("tests/lib/processors");
     }
-
 };

--- a/rule/index.js
+++ b/rule/index.js
@@ -24,10 +24,10 @@ var isRequired = validators.isRequired;
 //------------------------------------------------------------------------------
 
 var ESLintRuleGenerator = module.exports = function ESLintRuleGenerator() {
-    yeoman.generators.Base.apply(this, arguments);
+    yeoman.Base.apply(this, arguments);
 };
 
-util.inherits(ESLintRuleGenerator, yeoman.generators.Base);
+util.inherits(ESLintRuleGenerator, yeoman.Base);
 
 ESLintRuleGenerator.prototype.askFor = function askFor() {
     var cb = this.async();
@@ -71,12 +71,9 @@ ESLintRuleGenerator.prototype.askFor = function askFor() {
         cb();
 
     }.bind(this));
-
-
 };
 
 ESLintRuleGenerator.prototype.generate = function generate() {
-
     this.template("_doc.md", "docs/rules/" + this.ruleId + ".md");
     this.template("_rule.js", "lib/rules/" + this.ruleId + ".js");
     this.template("_test.js", "tests/lib/rules/" + this.ruleId + ".js");

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -13,8 +13,8 @@
 //------------------------------------------------------------------------------
 
 var path = require("path"),
-    helpers = require("yeoman-generator").test,
-    assert = require("yeoman-generator").assert;
+    helpers = require("yeoman-test"),
+    assert = require("yeoman-assert");
 
 //------------------------------------------------------------------------------
 // Tests


### PR DESCRIPTION
Updated all of generator-eslint's dependencies and fixed the deprecation warnings those updates produced. Updated .travis.yml to run tests in more Node versions (0.12, 4, 5).