### PR TITLE
Fix: Update eslint dep in generated package.json (fixes #14)

### DIFF
--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -16,7 +16,7 @@
     "requireindex": "~1.1.0"
   },
   "devDependencies": {
-    "eslint": "~1.2.0"
+    "eslint": "~2.6.0"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Updated the eslint dependency to 2.6.0 (latest) in the package.json template for `yo eslint:plugin`.