### PR TITLE
New: Main generator (calls existing generators) (fixes #31)

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Main generator (delegates to rule or plugin generator)
+ * @author Kevin Partington
+ * @copyright jQuery Foundation and other contributors, https://jquery.org/
+ * MIT License
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var yeoman = require("yeoman-generator");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+var NAMESPACES = {
+    Rule: "eslint:rule",
+    Plugin: "eslint:plugin"
+};
+
+//------------------------------------------------------------------------------
+// Constructor
+//------------------------------------------------------------------------------
+
+module.exports = yeoman.Base.extend({
+    prompting: function() {
+        var done = this.async();
+
+        this.prompt({
+            type: "list",
+            name: "outputType",
+            message: "Do you want to generate a rule or a plugin?",
+            choices: ["Rule", "Plugin"],
+            default: "Rule"
+        }, function(answers) {
+            this.composeWith(NAMESPACES[answers.outputType]);
+            done();
+        }.bind(this));
+    }
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "main": "app/index.js",
   "files": [
+    "app",
     "lib",
     "plugin",
     "rule"
@@ -35,6 +36,7 @@
     "eslint-config-eslint": "^3.0.0",
     "eslint-release": "^0.9.2",
     "mocha": "^2.4.5",
+    "sinon": "^1.17.5",
     "yeoman-assert": "^2.1.2",
     "yeoman-test": "^1.1.0"
   },

--- a/test/test-main.js
+++ b/test/test-main.js
@@ -1,0 +1,103 @@
+/**
+ * @fileoverview Main generator tests
+ * @author Kevin Partington
+ */
+/* eslint no-invalid-this:0 */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("yeoman-assert"),
+    generators = require("yeoman-generator"),
+    helpers = require("yeoman-test"),
+    path = require("path"),
+    sinon = require("sinon");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("ESLint Main Generator", function() {
+    var sandbox = sinon.sandbox.create();
+
+    before(function(done) {
+        this.spy = sandbox.spy();
+
+        this.dummyGenerator = generators.Base.extend({
+            exec: this.spy
+        });
+
+        helpers.testDirectory(path.join(__dirname, "temp"), done);
+    });
+
+    beforeEach(function() {
+        this.spy.reset();
+    });
+
+    describe("User answers with Plugin", function() {
+        beforeEach(function(done) {
+
+            /*
+             * Adapted from:
+             * http://stackoverflow.com/questions/27643601/testing-yeomans-composewith
+             * Adapted to use createGenerator and the .run() method on generator
+             * instances. The idea is that the dummyGenerator is being assigned
+             * the namespace "eslint:plugin" for this test, so when the main
+             * generator invokes "eslint:plugin", it will run our
+             * dummyGenerator's exec() function and thus call our spy.
+             */
+
+            this.eslintGenerator = helpers.createGenerator("eslint", [
+                "../../app",
+                [this.dummyGenerator, "eslint:plugin"]
+            ]);
+
+            helpers.mockPrompt(this.eslintGenerator, {
+                outputType: "Plugin"
+            });
+
+            this.eslintGenerator.options["skip-install"] = true;
+
+            this.eslintGenerator.run(done);
+        });
+
+        it("should run the eslint:plugin generator", function() {
+            assert.ok(this.spy.calledOnce);
+        });
+    });
+
+    describe("User answers with Rule", function() {
+        beforeEach(function(done) {
+
+            /*
+             * Adapted from:
+             * http://stackoverflow.com/questions/27643601/testing-yeomans-composewith
+             * Adapted to use createGenerator and the .run() method on generator
+             * instances. The idea is that the dummyGenerator is being assigned
+             * the namespace "eslint:rule" for this test, so when the main
+             * generator invokes "eslint:rule", it will run our dummyGenerator's
+             * exec() function and thus call our spy.
+             */
+
+            this.eslintGenerator = helpers.createGenerator("eslint", [
+                "../../app",
+                [this.dummyGenerator, "eslint:rule"]
+            ]);
+
+            helpers.mockPrompt(this.eslintGenerator, {
+                outputType: "Rule"
+            });
+
+            this.eslintGenerator.options["skip-install"] = true;
+
+            this.eslintGenerator.run(done);
+        });
+
+        it("should run the eslint:rule generator", function() {
+            assert.ok(this.spy.calledOnce);
+        });
+    });
+});
+


### PR DESCRIPTION
**What issue does this pull request address?**
#31 (lack of app generator, so users cannot run `yo eslint`)

**What changes did you make? (Give an overview)**

Created a new main generator class (`app/index.js` by convention). This generator asks one question (rule or plugin?) and then uses `.composeWith()` to delegate to the correct sub-generator.

**Is there anything you'd like reviewers to focus on?**

The testing approach had to be a bit different due to having to mock the `.composeWith()` call. Unfortunately it's not intuitive (even sboudrias admitted as much on Stack Overflow), and I had to make further changes. I added a couple of longer comments trying to explain it, but please let me know if I can improve it further (or if you know of a better way to do this test).

Also, I added the `sinon` package as a devDependency, hope that's okay.