### PR TITLE
Fix: Double quotes correctly escaped in JS/JSON files (fixes #42)

### DIFF
--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -1,13 +1,13 @@
 {
   "name": "eslint-plugin-<%= pluginId %>",
   "version": "0.0.0",
-  "description": "<%= desc %>",
+  "description": "<%- desc.replace(/"/g, '\\"') %>",
   "keywords": [
     "eslint",
     "eslintplugin",
     "eslint-plugin"
   ],
-  "author": "<%= userName %>",
+  "author": "<%- userName.replace(/"/g, '\\"') %>",
   "main": "lib/index.js",
   "scripts": {
     "test": "mocha tests --recursive"

--- a/rule/templates/_rule.js
+++ b/rule/templates/_rule.js
@@ -1,6 +1,6 @@
 /**
- * @fileoverview <%= desc %>
- * @author <%= userName %>
+ * @fileoverview <%- desc %>
+ * @author <%- userName %>
  */
 "use strict";
 
@@ -11,7 +11,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "<%= desc %>",
+            description: "<%- desc.replace(/"/g, '\\"') %>",
             category: "Fill me in",
             recommended: false
         },

--- a/rule/templates/_test.js
+++ b/rule/templates/_test.js
@@ -29,7 +29,7 @@ ruleTester.run("<%= ruleId %>", rule, {
 
     invalid: [
         {
-            code: "<%= invalidCode %>",
+            code: "<%- invalidCode.replace(/"/g, '\\"') %>",
             errors: [{
                 message: "Fill me in.",
                 type: "Me too"

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -87,38 +87,6 @@ describe("ESLint Rule Generator", function() {
             });
         });
 
-        /*
-         * TODO: (platinumazure) Uncomment when eslint/generator-eslint#44 is
-         * fixed.
-         */
-//        describe("Single quotes in description", function() {
-//            beforeEach(function(done) {
-//                helpers.mockPrompt(this.rule, {
-//                    userName: "",
-//                    ruleId: "test-rule",
-//                    desc: "My 'foo'",
-//                    invalidCode: "var x;",
-//                    target: "eslint"
-//                });
-//                this.rule.options["skip-install"] = true;
-//                this.rule.run(done);
-//            });
-//
-//            describe("Resulting rule file", function() {
-//                beforeEach(function() {
-//                    this.resultRuleModule = require(path.join(testDirectory, "lib", "rules", "test-rule"));
-//                });
-//
-//                it("should be requireable", function() {
-//                    assert.ok(this.resultRuleModule);
-//                });
-//
-//                it("should have correct description", function() {
-//                    assert.strictEqual(this.resultRuleModule.meta.docs.description, "My 'foo'");
-//                });
-//            });
-//        });
-
         describe("Double quotes in code snippet", function() {
             beforeEach(function(done) {
                 helpers.mockPrompt(this.rule, {
@@ -239,38 +207,6 @@ describe("ESLint Plugin Generator", function() {
                 });
             });
         });
-
-        /*
-         * TODO: (platinumazure) Uncomment when eslint/generator-eslint#44 is
-         * fixed.
-         */
-//        describe("Single quotes in description", function() {
-//            beforeEach(function(done) {
-//                helpers.mockPrompt(this.rule, {
-//                    userName: "",
-//                    pluginId: "test-plugin",
-//                    desc: "My 'foo'",
-//                    hasRules: false,
-//                    hasProcessors: false,
-//                });
-//                this.rule.options["skip-install"] = true;
-//                this.rule.run(done);
-//            });
-//
-//            describe("Resulting package.json", function() {
-//                beforeEach(function() {
-//                    this.resultPackageJson = require(path.join(testDirectory, "package.json"));
-//                });
-//
-//                it("should be requireable", function() {
-//                    assert.ok(this.resultPackageJson);
-//                });
-//
-//                it("should have correct description", function() {
-//                    assert.strictEqual(this.resultPackageJson.description, "My 'foo'");
-//                });
-//            });
-//        });
 
         describe("Double quotes in username", function() {
             beforeEach(function(done) {

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -11,7 +11,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var path = require("path"),
+var fs = require("fs"),
+    path = require("path"),
     helpers = require("yeoman-test"),
     assert = require("yeoman-assert");
 
@@ -19,9 +20,11 @@ var path = require("path"),
 // Tests
 //------------------------------------------------------------------------------
 
+var testDirectory = path.join(__dirname, "temp");
+
 describe("ESLint Rule Generator", function() {
     beforeEach(function(done) {
-        helpers.testDirectory(path.join(__dirname, "temp"), function(err) {
+        helpers.testDirectory(testDirectory, function(err) {
             if (err) {
                 return done(err);
             }
@@ -52,6 +55,96 @@ describe("ESLint Rule Generator", function() {
         this.rule.run(function() {
             assert.file(expected);
             done();
+        });
+    });
+
+    describe("With pathological input", function() {
+        describe("Double quotes in description", function() {
+            beforeEach(function(done) {
+                helpers.mockPrompt(this.rule, {
+                    userName: "",
+                    ruleId: "test-rule",
+                    desc: "My \"foo\"",
+                    invalidCode: "var x = \"foo\";",
+                    target: "eslint"
+                });
+                this.rule.options["skip-install"] = true;
+                this.rule.run(done);
+            });
+
+            describe("Resulting rule file", function() {
+                beforeEach(function() {
+                    this.resultRuleModule = require(path.join(testDirectory, "lib", "rules", "test-rule"));
+                });
+
+                it("should be requireable", function() {
+                    assert.ok(this.resultRuleModule);
+                });
+
+                it("should have correct description", function() {
+                    assert.strictEqual(this.resultRuleModule.meta.docs.description, "My \"foo\"");
+                });
+            });
+        });
+
+        /*
+         * TODO: (platinumazure) Uncomment when eslint/generator-eslint#44 is
+         * fixed.
+         */
+//        describe("Single quotes in description", function() {
+//            beforeEach(function(done) {
+//                helpers.mockPrompt(this.rule, {
+//                    userName: "",
+//                    ruleId: "test-rule",
+//                    desc: "My 'foo'",
+//                    invalidCode: "var x;",
+//                    target: "eslint"
+//                });
+//                this.rule.options["skip-install"] = true;
+//                this.rule.run(done);
+//            });
+//
+//            describe("Resulting rule file", function() {
+//                beforeEach(function() {
+//                    this.resultRuleModule = require(path.join(testDirectory, "lib", "rules", "test-rule"));
+//                });
+//
+//                it("should be requireable", function() {
+//                    assert.ok(this.resultRuleModule);
+//                });
+//
+//                it("should have correct description", function() {
+//                    assert.strictEqual(this.resultRuleModule.meta.docs.description, "My 'foo'");
+//                });
+//            });
+//        });
+
+        describe("Double quotes in code snippet", function() {
+            beforeEach(function(done) {
+                helpers.mockPrompt(this.rule, {
+                    userName: "",
+                    ruleId: "test-rule",
+                    desc: "My \"foo\"",
+                    invalidCode: "var x = \"foo\";",
+                    target: "eslint"
+                });
+                this.rule.options["skip-install"] = true;
+                this.rule.run(done);
+            });
+
+            describe("Resulting test file", function() {
+                beforeEach(function() {
+                    this.resultTestModuleContent = fs.readFileSync(path.join(testDirectory, "tests", "lib", "rules", "test-rule.js"), "utf8");
+                });
+
+                it("should be readable", function() {
+                    assert.ok(this.resultTestModuleContent);
+                });
+
+                it("should have correct code snippet", function() {
+                    assert.ok(this.resultTestModuleContent.indexOf("code: \"var x = \\\"foo\\\";") > -1);
+                });
+            });
         });
     });
 });
@@ -115,6 +208,96 @@ describe("ESLint Plugin Generator", function() {
         this.rule.run(function() {
             assert.file(expected);
             done();
+        });
+    });
+
+    describe("With pathological input", function() {
+        describe("Double quotes in description", function() {
+            beforeEach(function(done) {
+                helpers.mockPrompt(this.rule, {
+                    userName: "Kevin \"platinumazure\" Partington",
+                    pluginId: "test-plugin",
+                    desc: "My \"foo\"",
+                    hasRules: false,
+                    hasProcessors: false
+                });
+                this.rule.options["skip-install"] = true;
+                this.rule.run(done);
+            });
+
+            describe("Resulting package.json", function() {
+                beforeEach(function() {
+                    this.resultPackageJson = require(path.join(testDirectory, "package.json"));
+                });
+
+                it("should be requireable", function() {
+                    assert.ok(this.resultPackageJson);
+                });
+
+                it("should have correct description", function() {
+                    assert.strictEqual(this.resultPackageJson.description, "My \"foo\"");
+                });
+            });
+        });
+
+        /*
+         * TODO: (platinumazure) Uncomment when eslint/generator-eslint#44 is
+         * fixed.
+         */
+//        describe("Single quotes in description", function() {
+//            beforeEach(function(done) {
+//                helpers.mockPrompt(this.rule, {
+//                    userName: "",
+//                    pluginId: "test-plugin",
+//                    desc: "My 'foo'",
+//                    hasRules: false,
+//                    hasProcessors: false,
+//                });
+//                this.rule.options["skip-install"] = true;
+//                this.rule.run(done);
+//            });
+//
+//            describe("Resulting package.json", function() {
+//                beforeEach(function() {
+//                    this.resultPackageJson = require(path.join(testDirectory, "package.json"));
+//                });
+//
+//                it("should be requireable", function() {
+//                    assert.ok(this.resultPackageJson);
+//                });
+//
+//                it("should have correct description", function() {
+//                    assert.strictEqual(this.resultPackageJson.description, "My 'foo'");
+//                });
+//            });
+//        });
+
+        describe("Double quotes in username", function() {
+            beforeEach(function(done) {
+                helpers.mockPrompt(this.rule, {
+                    userName: "Kevin \"platinumazure\" Partington",
+                    pluginId: "test-plugin",
+                    desc: "My \"foo\"",
+                    hasRules: false,
+                    hasProcessors: false
+                });
+                this.rule.options["skip-install"] = true;
+                this.rule.run(done);
+            });
+
+            describe("Resulting package.json", function() {
+                beforeEach(function() {
+                    this.resultPackageJson = require(path.join(testDirectory, "package.json"));
+                });
+
+                it("should be requireable", function() {
+                    assert.ok(this.resultPackageJson);
+                });
+
+                it("should have correct author", function() {
+                    assert.strictEqual(this.resultPackageJson.author, "Kevin \"platinumazure\" Partington");
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See #42.

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- **n/a** I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

Throughout the generated file templates, we have used `<%= someVar %>` to interpolate user input into the templates. This uses HTML escaping by default and is not what we want most of the time.

Switching to `<%- someVar %>` prevents HTML escaping, but it leaves vulnerabilities for double quotes when interpolating into JS or JSON strings. So we need to also replace double quotes with backslash escaping.

In the future, it might be better to actually configure the EJS template function (per file) so that the "escape" function is JS double quote escaping, that way we can revert to using the escaped/unescaped interpolation notation for clarity.

**Is there anything you'd like reviewers to focus on?**

I've added some commented out tests for single quote cases, which shouldn't actually be pathological but which are worth testing. Unfortunately, due to some sort of caching in the test generator, new prompt answers aren't respected. For similar reasons I had to duplicate prompts elsewhere (e.g., including a double-quoted username in the test for double-quote description).

Please let me know if anything is unclear.