### PR TITLE
Chore: Use require-uncached to avoid stale cache in tests (fixes #44)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-config-eslint": "^3.0.0",
     "eslint-release": "^0.10.1",
     "mocha": "^2.4.5",
+    "require-uncached": "^1.0.2",
     "sinon": "^1.17.5",
     "yeoman-assert": "^2.1.2",
     "yeoman-test": "^1.1.0"

--- a/tests/plugin/index.js
+++ b/tests/plugin/index.js
@@ -12,6 +12,7 @@
 //------------------------------------------------------------------------------
 
 var path = require("path"),
+    requireUncached = require("require-uncached"),
     helpers = require("yeoman-test"),
     assert = require("yeoman-assert");
 
@@ -87,7 +88,7 @@ describe("ESLint Plugin Generator", function() {
         describe("Double quotes in description", function() {
             beforeEach(function(done) {
                 helpers.mockPrompt(this.rule, {
-                    userName: "Kevin \"platinumazure\" Partington",
+                    userName: "Kevin platinumazure Partington",
                     pluginId: "test-plugin",
                     desc: "My \"foo\"",
                     hasRules: false,
@@ -99,7 +100,7 @@ describe("ESLint Plugin Generator", function() {
 
             describe("Resulting package.json", function() {
                 beforeEach(function() {
-                    this.resultPackageJson = require(path.join(testDirectory, "package.json"));
+                    this.resultPackageJson = requireUncached(path.join(testDirectory, "package.json"));
                 });
 
                 it("should be requireable", function() {
@@ -117,7 +118,7 @@ describe("ESLint Plugin Generator", function() {
                 helpers.mockPrompt(this.rule, {
                     userName: "Kevin \"platinumazure\" Partington",
                     pluginId: "test-plugin",
-                    desc: "My \"foo\"",
+                    desc: "My foo",
                     hasRules: false,
                     hasProcessors: false
                 });
@@ -127,7 +128,7 @@ describe("ESLint Plugin Generator", function() {
 
             describe("Resulting package.json", function() {
                 beforeEach(function() {
-                    this.resultPackageJson = require(path.join(testDirectory, "package.json"));
+                    this.resultPackageJson = requireUncached(path.join(testDirectory, "package.json"));
                 });
 
                 it("should be requireable", function() {
@@ -136,6 +137,62 @@ describe("ESLint Plugin Generator", function() {
 
                 it("should have correct author", function() {
                     assert.strictEqual(this.resultPackageJson.author, "Kevin \"platinumazure\" Partington");
+                });
+            });
+        });
+
+        describe("Single quotes in description", function() {
+            beforeEach(function(done) {
+                helpers.mockPrompt(this.rule, {
+                    userName: "Kevin platinumazure Partington",
+                    pluginId: "test-plugin",
+                    desc: "My 'foo'",
+                    hasRules: false,
+                    hasProcessors: false
+                });
+                this.rule.options["skip-install"] = true;
+                this.rule.run(done);
+            });
+
+            describe("Resulting package.json", function() {
+                beforeEach(function() {
+                    this.resultPackageJson = requireUncached(path.join(testDirectory, "package.json"));
+                });
+
+                it("should be requireable", function() {
+                    assert.ok(this.resultPackageJson);
+                });
+
+                it("should have correct description", function() {
+                    assert.strictEqual(this.resultPackageJson.description, "My 'foo'");
+                });
+            });
+        });
+
+        describe("Single quotes in username", function() {
+            beforeEach(function(done) {
+                helpers.mockPrompt(this.rule, {
+                    userName: "Kevin 'platinumazure' Partington",
+                    pluginId: "test-plugin",
+                    desc: "My foo",
+                    hasRules: false,
+                    hasProcessors: false
+                });
+                this.rule.options["skip-install"] = true;
+                this.rule.run(done);
+            });
+
+            describe("Resulting package.json", function() {
+                beforeEach(function() {
+                    this.resultPackageJson = requireUncached(path.join(testDirectory, "package.json"));
+                });
+
+                it("should be requireable", function() {
+                    assert.ok(this.resultPackageJson);
+                });
+
+                it("should have correct author", function() {
+                    assert.strictEqual(this.resultPackageJson.author, "Kevin 'platinumazure' Partington");
                 });
             });
         });


### PR DESCRIPTION
Adding single quote pathological tests as well (although those aren't actually pathological for us, I just wanted to have coverage for weird input).

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] Add something to the core
[x] Other, please explain: The "bugfix" isn't user-facing, it just got in the way of writing good generator tests.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

See issue #44.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added require-uncached to devDependencies and used it in plugin/rule tests to avoid `require()` cache problems. Also improved tests and added some new tests.

**Is there anything you'd like reviewers to focus on?**

Should be pretty straightforward, let me know if you have questions.