### PR TITLE
Update: Plugin package.json template devDependencies upgrade (fixes #52)

### DIFF
--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -16,8 +16,8 @@
     "requireindex": "~1.1.0"
   },
   "devDependencies": {
-    "eslint": "~2.6.0",
-    "mocha": "^2.4.5"
+    "eslint": "~3.9.1",
+    "mocha": "^3.1.2"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Generated plugins will now use ESLint 3.x (specifically `~3.9.1`). This will help ensure that generated plugins with new-style rules won't run into problems.