### PR TITLE
Build: Pinning run-async dependency to 2.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "mkdirp": "^0.5.1",
+    "run-async": "2.2.x",
     "yeoman-generator": "^0.22.5"
   },
   "devDependencies": {


### PR DESCRIPTION
The `run-async` package released version 2.3.0 recently, which completely dropped support for Node 0.10 by removing a Promise polyfill they were using internally. This has broken [our master build](https://travis-ci.org/eslint/generator-eslint/builds/181813236).

We should drop Node 0.10 support at some point, but I'd rather do that as a semver-major change. For now, this PR just adds a run-async dependency (pinning at 2.2.x) so that `npm install` will install the right version on Travis and keep this package working in Node 0.10 for now.

If we merge this, we can cut a minor release (when we're done with any other features we may want to add), and then drop Node 0.10 and Node 5 support in a semver-major release.