### PR TITLE
Update: Generated rule doc uses core ESLint example headers (fixes #21)

### DIFF
--- a/rule/templates/_doc.md
+++ b/rule/templates/_doc.md
@@ -7,7 +7,7 @@ Please describe the origin of the rule here.
 
 This rule aims to...
 
-The following patterns are considered warnings:
+Examples of **incorrect** code for this rule:
 
 ```js
 
@@ -15,7 +15,7 @@ The following patterns are considered warnings:
 
 ```
 
-The following patterns are not warnings:
+Examples of **correct** code for this rule:
 
 ```js
 


### PR DESCRIPTION
Idea is that this will help core rule developers who use generator-eslint, and the language is pretty slick and generally applicable, but plugin rule authors can choose to change the text (like anything else in a Yeoman-generated scaffold).