### PR TITLE
Chore: Fix license field in package.json to be valid SPDX string

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,5 @@
     "node": ">=0.8.0",
     "npm": ">=1.2.10"
   },
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
This package was using the old-style metadata field. Updating to use just the SPDX string.

Assumption is we are using the MIT license (it sure looks like the MIT license, anyway). If I've got it wrong, let me know.