### PR TITLE
Chore: Updated the template devDependencies to fix vulnerabilities.

### DIFF
--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -16,8 +16,8 @@
     "requireindex": "~1.1.0"
   },
   "devDependencies": {
-    "eslint": "~3.9.1",
-    "mocha": "^3.1.2"
+    "eslint": "^7.1.0",
+    "mocha": "^7.2.0"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
# Motivation
The old template would generate a plugin project folder that contained vulnerable versions of mocha. This fix was attempted in #64 but wasn't merged because Travis was configured to support older versions of node.js. Looks like #68 dropped support for older versions of node.js and now we are safe to update these deps in the template.