### PR TITLE
New: Add `eslint-plugin-eslint-plugin` to plugin generator

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -78,6 +78,7 @@ ESLintPluginGenerator.prototype.generate = function generate() {
     mkdirp.sync("lib");
     mkdirp.sync("tests");
     mkdirp.sync("tests/lib");
+    this.template("_.eslintrc.js", ".eslintrc.js");
     this.template("_plugin.js", "lib/index.js");
     this.template("_package.json", "package.json");
     this.template("_README.md", "README.md");

--- a/plugin/templates/_.eslintrc.js
+++ b/plugin/templates/_.eslintrc.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  root: true,
+  extends: [
+    'eslint:recommended',
+    'plugin:eslint-plugin/recommended',
+  ],
+  env: {
+    node: true,
+  },
+  overrides: [
+    {
+      files: ['tests/**/*.js'],
+      env: { mocha: true },
+    },
+  ]
+};

--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -10,6 +10,7 @@
   "author": "<%- userName.replace(/"/g, '\\"') %>",
   "main": "lib/index.js",
   "scripts": {
+    "lint": "eslint .",
     "test": "mocha tests --recursive"
   },
   "dependencies": {
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "eslint": "^7.1.0",
+    "eslint-plugin-eslint-plugin": "^3.2.0",
     "mocha": "^9.0.0"
   },
   "engines": {


### PR DESCRIPTION
Partially fixes #65.

We want to encourage the adoption of [eslint-plugin-eslint-plugin](https://www.npmjs.com/package/eslint-plugin-eslint-plugin) to help ESLint plugin authors follow best practices including avoiding using deprecated APIs and producing rules with good usability.

I'll follow-up after this to add eslint-plugin-node and make some other improvements too.