### PR TITLE
Fix: Use caret range for `requireindex` in template

### DIFF
--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -14,7 +14,7 @@
     "test": "mocha tests --recursive"
   },
   "dependencies": {
-    "requireindex": "~1.1.0"
+    "requireindex": "^1.1.0"
   },
   "devDependencies": {
     "eslint": "^7.1.0",


### PR DESCRIPTION
Avoid unnecessarily constraining the dependency versions which prevents users from receiving patch/minor updates.