### PR TITLE
Update: Drop Node 10 from generated plugin template

### DIFF
--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -20,7 +20,7 @@
     "mocha": "^7.2.0"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": "12.x || 14.x || >= 16"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
This is only affecting the generated plugin template so I'd argue it's not a breaking change like #81 is.

We now support Node 12, 14, 16+.

* Node 10 end-of-life 2021-04-30
* Node 13 end-of-life 2020-06-01
* Node 15 end-of-life 2021-06-01

https://nodejs.org/en/about/releases/
https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md
https://en.wikipedia.org/wiki/Node.js#Releases