### PR TITLE
Update: Add ESLint 6+ peer dependency to generated plugin template

### DIFF
--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -22,5 +22,8 @@
   "engines": {
     "node": ">=0.10.0"
   },
+  "peerDependencies": {
+    "eslint": ">=6"
+  },
   "license": "ISC"
 }


### PR DESCRIPTION
Supporting the last 2-3 major ESLint versions should be sufficient and enables ESLint plugin developers to use newer ESLint features.

ESLint 6 released 2019-06
ESLint 7 released 2020-05
ESLint 8 coming soon