### PR TITLE
New: Add `eslint-plugin-node` to plugin generator

### DIFF
--- a/plugin/templates/_.eslintrc.js
+++ b/plugin/templates/_.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:eslint-plugin/recommended',
+    'plugin:node/recommended',
   ],
   env: {
     node: true,

--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "eslint": "^7.1.0",
     "eslint-plugin-eslint-plugin": "^3.2.0",
+    "eslint-plugin-node": "^11.0.0",
     "mocha": "^9.0.0"
   },
   "engines": {


### PR DESCRIPTION
Fixes #65.

We want to encourage plugin developers to use appropriate linting to help them produce high-quality plugins.