### PR TITLE
Chore: Remove unused dependency `run-async`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "run-async": "2.2.x",
         "yeoman-generator": "^0.22.5"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "publish-release": "eslint-publish-release"
   },
   "dependencies": {
-    "run-async": "2.2.x",
     "yeoman-generator": "^0.22.5"
   },
   "devDependencies": {


### PR DESCRIPTION
No references to it in the codebase.

Part of #86.