### PR TITLE
Update: Move `ESLint Plugin` before `ESLint Core` in CLI prompt

### DIFF
--- a/rule/index.js
+++ b/rule/index.js
@@ -41,8 +41,8 @@ ESLintRuleGenerator.prototype.askFor = function askFor() {
         name: "target",
         message: "Where will this rule be published?",
         choices: [
-            { name: "ESLint Core", value: "eslint" },
-            { name: "ESLint Plugin", value: "plugin" }
+            { name: "ESLint Plugin", value: "plugin" },
+            { name: "ESLint Core", value: "eslint" }
         ]
     }, {
         type: "input",


### PR DESCRIPTION
Since it's more common for consumers to use this for generating ESLint plugin rules than ESLint core rules. We want the more common usage to be the default (first).

In this CLI prompt:

```
yo eslint:rule
? What is your name? John Doe
? Where will this rule be published? (Use arrow keys)
❯ ESLint Plugin
  ESLint Core
```