### PR TITLE
Update: Add placeholder for `meta.type` in rule template

### DIFF
--- a/rule/templates/_rule.js
+++ b/rule/templates/_rule.js
@@ -10,6 +10,7 @@
 
 module.exports = {
     meta: {
+        type: null, // `problem`, `suggestion`, or `layout`
         docs: {
             description: "<%- desc.replace(/"/g, '\\"') %>",
             category: "Fill me in",


### PR DESCRIPTION
To encourage rule authors to fill in the rule type: https://eslint.org/docs/developer-guide/working-with-rules#rule-basics

Related: https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/require-meta-type.md