### PR TITLE
Update: Add placeholder for `meta.docs.url` in rule template

### DIFF
--- a/rule/templates/_rule.js
+++ b/rule/templates/_rule.js
@@ -13,7 +13,8 @@ module.exports = {
         docs: {
             description: "<%- desc.replace(/"/g, '\\"') %>",
             category: "Fill me in",
-            recommended: false
+            recommended: false,
+            url: null, // URL to the documentation page for this rule
         },
         fixable: null,  // or "code" or "whitespace"
         schema: [


### PR DESCRIPTION
To encourage rule authors to fill in the rule URL so that IDEs / code editors can provide a link to rule documentation on violations: https://eslint.org/docs/developer-guide/working-with-rules#rule-basics

Related: https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/require-meta-docs-url.md