### PR TITLE
Chore: Use `npm ci` in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '16.x'
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Lint files
         run: npm run lint
   test:
@@ -36,6 +36,6 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
     - name: Install dependencies
-      run: npm install
+      run: npm ci
     - name: Run tests
       run: npm test


### PR DESCRIPTION
This ensures the lockfile is always up-to-date, among other benefits.

https://docs.npmjs.com/cli/v7/commands/npm-ci