### PR TITLE
Update: Fix linting inconsistencies in templates

### DIFF
--- a/plugin/templates/_.eslintrc.js
+++ b/plugin/templates/_.eslintrc.js
@@ -1,19 +1,19 @@
-'use strict';
+"use strict";
 
 module.exports = {
   root: true,
   extends: [
-    'eslint:recommended',
-    'plugin:eslint-plugin/recommended',
-    'plugin:node/recommended',
+    "eslint:recommended",
+    "plugin:eslint-plugin/recommended",
+    "plugin:node/recommended",
   ],
   env: {
     node: true,
   },
   overrides: [
     {
-      files: ['tests/**/*.js'],
+      files: ["tests/**/*.js"],
       env: { mocha: true },
     },
-  ]
+  ],
 };

--- a/plugin/templates/_plugin.js
+++ b/plugin/templates/_plugin.js
@@ -22,7 +22,6 @@ module.exports.rules = requireIndex(__dirname + "/rules");
 <% if (hasProcessors) { %>
 // import processors
 module.exports.processors = {
-
-    // add your processors here
+  // add your processors here
 };
 <% } %>

--- a/rule/templates/_rule.js
+++ b/rule/templates/_rule.js
@@ -9,36 +9,33 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
-    meta: {
-        type: null, // `problem`, `suggestion`, or `layout`
-        docs: {
-            description: "<%- desc.replace(/"/g, '\\"') %>",
-            category: "Fill me in",
-            recommended: false,
-            url: null, // URL to the documentation page for this rule
-        },
-        fixable: null,  // or "code" or "whitespace"
-        schema: [], // Add a schema if the rule has options
+  meta: {
+    type: null, // `problem`, `suggestion`, or `layout`
+    docs: {
+      description: "<%- desc.replace(/"/g, '\\"') %>",
+      category: "Fill me in",
+      recommended: false,
+      url: null, // URL to the documentation page for this rule
     },
+    fixable: null, // Or `code` or `whitespace`
+    schema: [], // Add a schema if the rule has options
+  },
 
-    create: function(context) {
+  create(context) {
+    // variables should be defined here
 
-        // variables should be defined here
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
 
-        //----------------------------------------------------------------------
-        // Helpers
-        //----------------------------------------------------------------------
+    // any helper functions should go here or else delete this section
 
-        // any helper functions should go here or else delete this section
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
 
-        //----------------------------------------------------------------------
-        // Public
-        //----------------------------------------------------------------------
-
-        return {
-
-            // give me methods
-
-        };
-    }
+    return {
+      // visitor functions for different types of nodes
+    };
+  },
 };

--- a/rule/templates/_test.js
+++ b/rule/templates/_test.js
@@ -8,32 +8,26 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var rule = require("../../../lib/rules/<%= ruleId %>"),
-<% if (target === "eslint") { %>
-    RuleTester = require("../../../lib/testers/rule-tester");
+const rule = require("../../../lib/rules/<%= ruleId %>"),<% if (target === "eslint") { %>
+  RuleTester = require("../../../lib/testers/rule-tester");
 <% } else { %>
-    RuleTester = require("eslint").RuleTester;
+  RuleTester = require("eslint").RuleTester;
 <% } %>
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-var ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
 ruleTester.run("<%= ruleId %>", rule, {
+  valid: [
+    // give me some code that won't trigger a warning
+  ],
 
-    valid: [
-
-        // give me some code that won't trigger a warning
-    ],
-
-    invalid: [
-        {
-            code: "<%- invalidCode.replace(/"/g, '\\"') %>",
-            errors: [{
-                message: "Fill me in.",
-                type: "Me too"
-            }]
-        }
-    ]
+  invalid: [
+    {
+      code: "<%- invalidCode.replace(/"/g, '\\"') %>",
+      errors: [{ message: "Fill me in.", type: "Me too" }],
+    },
+  ],
 });


### PR DESCRIPTION
Fixes #95.

Applies the default prettier formatting to all the template files. The goal is that a generated plugin/rule will be fully-ready (no violations) for anyone who wants to use prettier to lint their ESLint plugin.