### PR TITLE
Docs: Switch to single-line comment for rule jsdoc type

### DIFF
--- a/rule/templates/_rule.js
+++ b/rule/templates/_rule.js
@@ -8,9 +8,7 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-/**
- * @type {import('eslint').Rule.RuleModule}
- */
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: null, // `problem`, `suggestion`, or `layout`


### PR DESCRIPTION
There's no need for this to take up multiple lines.