### PR TITLE
fix: remove unused meta.docs.category field in rule template

### DIFF
--- a/rule/templates/_rule.js
+++ b/rule/templates/_rule.js
@@ -14,7 +14,6 @@ module.exports = {
     type: null, // `problem`, `suggestion`, or `layout`
     docs: {
       description: "<%- desc.replace(/"/g, '\\"') %>",
-      category: "Fill me in",
       recommended: false,
       url: null, // URL to the documentation page for this rule
     },


### PR DESCRIPTION
Resolves #131 

There didn't seem to be any tests that broke from this change so I imagine it was more of a 'content' detail and we're safe to leave it without tests. Let me know if there's anything I missed!