### PR TITLE
feat: upgrade plugin template dependencies

### DIFF
--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -17,10 +17,10 @@
     "requireindex": "^1.2.0"
   },
   "devDependencies": {
-    "eslint": "^8.0.1",
-    "eslint-plugin-eslint-plugin": "^4.0.1",
+    "eslint": "^8.19.0",
+    "eslint-plugin-eslint-plugin": "^5.0.0",
     "eslint-plugin-node": "^11.1.0",
-    "mocha": "^9.1.3"
+    "mocha": "^10.0.0"
   },
   "engines": {
     "node": "12.x || 14.x || >= 16"


### PR DESCRIPTION
* https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/releases/tag/v5.0.0
* https://github.com/mochajs/mocha/releases/tag/v10.0.0

Since these major version updates dropped Node 12 support, this PR depends on us also dropping Node 12 support:
* https://github.com/eslint/generator-eslint/pull/135