### PR TITLE
feat: strictly define Node API in plugin template

### DIFF
--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -8,7 +8,8 @@
     "eslint-plugin"
   ],
   "author": "<%- userName.replace(/"/g, '\\"') %>",
-  "main": "lib/index.js",
+  "main": "./lib/index.js",
+  "exports": "./lib/index.js",
   "scripts": {
     "lint": "eslint .",
     "test": "mocha tests --recursive"


### PR DESCRIPTION
This follows the lead of ESLint core and other ESLint plugins in strictly defining their Node API so that users cannot reach in and import/depend on arbitrary files inside the plugin.

* https://eslint.org/docs/latest/user-guide/migrating-to-8.0.0#remove-lib
   > Beginning in v8.0.0, ESLint is strictly defining its public API. Previously, you could reach into individual files such as require("eslint/lib/rules/semi") and this is no longer allowed. There are a limited number of existing APIs that are now available through the /use-at-your-own-risk entrypoint for backwards compatibility, but these APIs are not formally supported and may break or disappear at any point in time.

https://nodejs.org/api/packages.html#main-entry-point-export