### PR TITLE
feat: drop ESLint v6 support in plugin template

### DIFF
--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -26,7 +26,7 @@
     "node": "12.x || 14.x || >= 16"
   },
   "peerDependencies": {
-    "eslint": ">=6"
+    "eslint": ">=7"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
ESLint v6 was released in [2019](https://eslint.org/blog/2019/06/eslint-v6.0.0-released/). Supporting the last two versions, ESLint v7 and ESLint v8, should be sufficient. ESLint v9 will also be released later this year.
