### PR TITLE
feat: add eslint-doc-generator to plugin template

### DIFF
--- a/plugin/templates/_README.md
+++ b/plugin/templates/_README.md
@@ -39,8 +39,10 @@ Then configure the rules you want to use under the rules section.
 }
 ```
 
-## Supported Rules
+## Rules
 
-* Fill in provided rules here
+<!-- begin auto-generated rules list -->
+TODO: Run eslint-doc-generator to generate the rules list.
+<!-- end auto-generated rules list -->
 
 <% } %>

--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -11,17 +11,22 @@
   "main": "./lib/index.js",
   "exports": "./lib/index.js",
   "scripts": {
-    "lint": "eslint .",
-    "test": "mocha tests --recursive"
+    "lint": "npm-run-all \"lint:*\"",
+    "lint:eslint-docs": "npm-run-all \"update:eslint-docs -- --check\"",
+    "lint:js": "eslint .",
+    "test": "mocha tests --recursive",
+    "update:eslint-docs": "eslint-doc-generator"
   },
   "dependencies": {
     "requireindex": "^1.2.0"
   },
   "devDependencies": {
     "eslint": "^8.19.0",
+    "eslint-doc-generator": "^1.0.0",
     "eslint-plugin-eslint-plugin": "^5.0.0",
     "eslint-plugin-node": "^11.1.0",
-    "mocha": "^10.0.0"
+    "mocha": "^10.0.0",
+    "npm-run-all": "^4.1.5"
   },
   "engines": {
     "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"

--- a/rule/templates/_doc.md
+++ b/rule/templates/_doc.md
@@ -1,4 +1,4 @@
-# <%= desc %> (<%= ruleId %>)
+# <%= desc %> (`<%= ruleId %>`)
 
 Please describe the origin of the rule here.
 

--- a/tests/rule/index.js
+++ b/tests/rule/index.js
@@ -52,7 +52,7 @@ describe("ESLint Rule Generator", () => {
         });
 
         it("has correct rule doc file contents", () => {
-            assert.fileContent("docs/rules/no-unused-vars.md", "# Don&#39;t include unused variables. (no-unused-vars)");
+            assert.fileContent("docs/rules/no-unused-vars.md", "# Don&#39;t include unused variables. (`no-unused-vars`)");
         });
 
         it("has correct rule test file contents", () => {


### PR DESCRIPTION
[eslint-doc-generator](https://github.com/bmish/eslint-doc-generator) is a CLI tool I built for automating the generation of the README rules list table and rule doc title/notices (e.g. auto-fixable, has suggestions, deprecated, etc) for ESLint plugins. It follows common documentation conventions from ESLint and top ESLint plugins and will help us standardize documentation across ESLint plugins (and generally improve the usability of custom rules through better documentation as well as streamline the process of adding new rules). It has 100% test coverage and is [used in many](https://github.com/bmish/eslint-doc-generator#users) of the top ESLint plugins already. 

The primary change in this PR is to install the new dev-dependency and add the following scripts to the plugin template package.json:
*  `npm run update:eslint-docs` for the plugin author to update their documentation whenever adding a rule or changing rule metadata
* `npm run lint:eslint-docs` which ensures the plugin's documentation is up-to-date (for running locally or during CI)