### PR TITLE
chore: Set up release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: lts/*
           registry-url: https://registry.npmjs.org
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,3 +26,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}
+      - run: 'npx @humanwhocodes/tweet "generator-eslint ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+          TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+          TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,32 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: generator-eslint
+      - uses: actions/checkout@v3
+        if: ${{ steps.release.outputs.release_created }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: https://registry.npmjs.org
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm ci
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm test
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,10 +22,6 @@ jobs:
           node-version: lts/*
           registry-url: https://registry.npmjs.org
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm ci
-        if: ${{ steps.release.outputs.release_created }}
-      - run: npm test
-        if: ${{ steps.release.outputs.release_created }}
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This configures the [release-please action][1] for `generator-eslint`. As we merge changes using [Conventional Commits formatting][2], release-please will create and update a pending release PR. That PR will contain a changelog of any commits merged since the prior release. When we're ready to do the release, we'll merge that PR, and the workflow in this PR will update the changelog and publish the release to GitHub and npm.

Separate from the code in this PR, I had to take a few manual steps:

1. Create a new [npm granular access token][3].
   1. Name it ~~`release-please $package-name`~~ `release-please`.
   1. Choose a reasonable expiration. I went with 365 days.
   1. Under Packages and Scopes > select "Read and write" access > select ~~"Only select packages and scopes" > select the package that we're setting up.~~ "All packages".
   1. The token should not have Organization access.
   1. Generate the token.
1. Copy the generated token as a ~~[new repository secret][4]~~ [new organization secret](https://github.com/organizations/eslint/settings/secrets/actions) named `NPM_TOKEN`, and give access to the desired repository. If the token already exists, edit it to include access for the desired repository.
1. Edit the four Twitter API [organization access tokens](https://github.com/organizations/eslint/settings/secrets/actions) to grant access to the repository.
1. In the [repository's Actions settings][5], under "Workflow permissions", ensure "Allow GitHub Actions to create and approve pull requests" is checked.

[1]: https://github.com/google-github-actions/release-please-action
[2]: https://www.conventionalcommits.org/en/v1.0.0/
[3]: https://www.npmjs.com/settings/eslintbot/tokens/granular-access-tokens/new
[4]: https://github.com/eslint/generator-eslint/settings/secrets/actions/new
[5]: https://github.com/eslint/generator-eslint/settings/actions