### PR TITLE
ci: remove scope from release PR title

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           release-type: node
           package-name: generator-eslint
+          pull-request-title-pattern: 'chore: release${component} ${version}'
       - uses: actions/checkout@v3
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v3


### PR DESCRIPTION
The default PR title is `chore${scope}: release${component} ${version}`, but our commit title bot doesn't expect scopes after the tag.