### PR TITLE
feat: add auto-generated configs list to readme in template

### DIFF
--- a/plugin/templates/_README.md
+++ b/plugin/templates/_README.md
@@ -39,6 +39,16 @@ Then configure the rules you want to use under the rules section.
 }
 ```
 
+<% } %>
+
+## Configurations
+
+<!-- begin auto-generated configs list -->
+TODO: Run eslint-doc-generator to generate the configs list (or delete this section if no configs are offered).
+<!-- end auto-generated configs list -->
+
+<% if (hasRules) { %>
+
 ## Rules
 
 <!-- begin auto-generated rules list -->


### PR DESCRIPTION
Builds on top of the original PR to add [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator):
* https://github.com/eslint/generator-eslint/pull/140

Adds a placeholder section for configs, similar to the existing rules section below it, which can turn into something like this when running `npm run update:eslint-docs`:

|    | Name          | Description                                      |
| :- | :------------ | :----------------------------------------------- |
| ✅  | `recommended` | These rules are recommended for everyone.        |
| 🎨 | `stylistic`   | These rules are more about code style than bugs. |
| ⌨️ | `typescript`  | These are good rules to use with TypeScript.     |

This feature shipped in:
* https://github.com/bmish/eslint-doc-generator/releases/tag/v1.5.0
* https://github.com/bmish/eslint-doc-generator/pull/480