### PR TITLE
chore: Update add-to-triage.yml

### DIFF
--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -4,9 +4,6 @@ on:
   issues:
     types:
       - opened
-  pull_request:
-    types:
-      - opened
 
 jobs:
   add-to-project:


### PR DESCRIPTION
Adding pull requests to the triage board always fails due to wacky GitHub permissions, so removing it in order for pull request checks to come back clean.