### PR TITLE
ci: don't install latest npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,18 +25,33 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [20.x, 19.x, 18.x, 16.x, 14.x]
+        versions:
+          - node: 20.x
+            npm: '10'
+          - node: 19.x
+            npm: '9'
+          - node: 18.x
+            npm: '10'
+          - node: 16.x
+            npm: '9'
+          - node: 14.x
+            npm: '9'
         include:
         - os: windows-latest
-          node: "18.x"
+          versions:
+            - node: 18.x
+              npm: '10'
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: ${{ matrix.node }}
-    - name: Install latest NPM
-      run: npm install -g npm@latest
+        node-version: ${{ matrix.versions.node }}
+    - name: Install latest supported NPM
+      shell: bash
+      run: |
+        npm install -g npm@${{ matrix.versions.npm }}
+        echo -n "Installed npm version is `npm -v`"
     - name: Install dependencies
       run: npm ci
     - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,33 +25,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        versions:
-          - node: 20.x
-            npm: '10'
-          - node: 19.x
-            npm: '9'
-          - node: 18.x
-            npm: '10'
-          - node: 16.x
-            npm: '9'
-          - node: 14.x
-            npm: '9'
+        node: [20.x, 19.x, 18.x, 16.x, 14.x]
         include:
         - os: windows-latest
-          versions:
-            - node: 18.x
-              npm: '10'
+          node: "18.x"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: ${{ matrix.versions.node }}
-    - name: Install latest supported NPM
-      shell: bash
-      run: |
-        npm install -g npm@${{ matrix.versions.npm }}
-        echo -n "Installed npm version is `npm -v`"
+        node-version: ${{ matrix.node }}
     - name: Install dependencies
       run: npm ci
     - name: Run tests


### PR DESCRIPTION
This PR fixes the CI test jobs.

Currently, the jobs will attempt to install the latests version of npm regardless of the installed version of Node.js. This has been problematic since the release of npm 10, because npm 10 does not support all versions of Node.js that this package supports.

~The fix is to explicitly indicate which version of npm (currently 9 or 10) should be installed along with Node.js.~ Upgrading npm doesn't seem necessary, so removing that step will fix the build.