### PR TITLE
chore: update dependency eslint-release to ^3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "eslint": "^8.19.0",
         "eslint-config-eslint": "^7.0.0",
-        "eslint-release": "^3.2.0",
+        "eslint-release": "^3.2.2",
         "markdownlint-cli": "^0.31.1",
         "mocha": "^10.0.0",
         "npm-run-all": "^4.1.5",
@@ -2587,16 +2587,15 @@
       }
     },
     "node_modules/eslint-release": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-release/-/eslint-release-3.2.0.tgz",
-      "integrity": "sha512-H64l+9wdlXdMWzAJRtalOoyLjJM2ub44URklHsl/ZpKX9LOhdv0vq8ZBLPFMd3mb6RquadO6MzebQarTAoxeBg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-release/-/eslint-release-3.2.2.tgz",
+      "integrity": "sha512-D606ic8e3WMx9Q8btEJu7dA9WjaHyPVac1IQHMp+YcW+pQRP/SSct0X1A+53a9l1XQqka9J+jTrY/Y/T46kEEg==",
       "dev": true,
       "dependencies": {
         "dateformat": "^3.0.3",
         "github-api": "^3.2.2",
         "linefix": "^0.1.1",
-        "semver": "^6.1.1",
-        "shelljs": "^0.8.3"
+        "semver": "^6.1.1"
       },
       "bin": {
         "eslint-generate-prerelease": "bin/eslint-generate-prerelease.js",
@@ -12376,16 +12375,15 @@
       }
     },
     "eslint-release": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-release/-/eslint-release-3.2.0.tgz",
-      "integrity": "sha512-H64l+9wdlXdMWzAJRtalOoyLjJM2ub44URklHsl/ZpKX9LOhdv0vq8ZBLPFMd3mb6RquadO6MzebQarTAoxeBg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-release/-/eslint-release-3.2.2.tgz",
+      "integrity": "sha512-D606ic8e3WMx9Q8btEJu7dA9WjaHyPVac1IQHMp+YcW+pQRP/SSct0X1A+53a9l1XQqka9J+jTrY/Y/T46kEEg==",
       "dev": true,
       "requires": {
         "dateformat": "^3.0.3",
         "github-api": "^3.2.2",
         "linefix": "^0.1.1",
-        "semver": "^6.1.1",
-        "shelljs": "^0.8.3"
+        "semver": "^6.1.1"
       },
       "dependencies": {
         "semver": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "eslint": "^8.19.0",
     "eslint-config-eslint": "^7.0.0",
-    "eslint-release": "^3.2.0",
+    "eslint-release": "^3.2.2",
     "markdownlint-cli": "^0.31.1",
     "mocha": "^10.0.0",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
This PR updates the eslint-release dev dependency to [v3.2.2](https://github.com/eslint/eslint-release/releases/tag/v3.2.2).