### PR TITLE
feat: add messages to rule template

### DIFF
--- a/rule/templates/_rule.js
+++ b/rule/templates/_rule.js
@@ -19,6 +19,7 @@ module.exports = {
     },
     fixable: null, // Or `code` or `whitespace`
     schema: [], // Add a schema if the rule has options
+    messages: {} // Add messageId and message
   },
 
   create(context) {

--- a/rule/templates/_rule.js
+++ b/rule/templates/_rule.js
@@ -19,7 +19,7 @@ module.exports = {
     },
     fixable: null, // Or `code` or `whitespace`
     schema: [], // Add a schema if the rule has options
-    messages: {} // Add messageId and message
+    messages: {}, // Add messageId and message
   },
 
   create(context) {


### PR DESCRIPTION
- closes #181

## Issue

After creating a plugin with `yo eslint:plugin`, then a rule with `yo eslint:rule`, executing linting with `npx eslint .` produces the following error and there is no related property for this in the skeleton rule which has been created.

> error  `meta.messages` must contain at least one violation message      eslint-plugin/prefer-message-ids

## Change

```js
    messages: {}, // Add messageId and message
```

is added to [rule/templates/_rule.js](https://github.com/eslint/generator-eslint/blob/main/rule/templates/_rule.js)

## References

- Rule [eslint-plugin/prefer-message-ids](https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/HEAD/docs/rules/prefer-message-ids.md)
- [MessageIds](https://eslint.org/docs/latest/extend/custom-rules#messageids)
