### PR TITLE
docs: align readme node.js with package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ First and foremost, you must have [Node.js](https://nodejs.org/) and npm install
 
 > **Requirements**
 >
-> - Node.js ^14.17.0 || ^16.0.0 || >= 18.0.0
+> - Node.js ^18.18.0 || ^20.9.0 || >=21.1.0
 
 You must also install Yeoman, if you don't have it installed already. To install Yeoman, you can run this command:
 


### PR DESCRIPTION
## Issue

- PR https://github.com/eslint/generator-eslint/pull/169 bumped the Node.js requirements to

https://github.com/eslint/generator-eslint/blob/92a44afb6bb04bd7b247111aa9d0f2c2b07558b2/package.json#L53-L55

whilst [README > Installation](https://github.com/eslint/generator-eslint/blob/main/README.md#installation) was left unchanged stating

> **Requirements**
>
> - Node.js ^14.17.0 || ^16.0.0 || >= 18.0.0

## Change

[README > Installation](https://github.com/eslint/generator-eslint/blob/main/README.md#installation) is updated to read

> **Requirements**
>
> - Node.js ^18.18.0 || ^20.9.0 || >=21.1.0

in line with [package.json](https://github.com/eslint/generator-eslint/blob/main/package.json)
