### PR TITLE
chore: add `.vscode` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 temp/
 npm-debug.log
 .eslint-release-info.json
+/.vscode/


### PR DESCRIPTION
Adds `/.vscode/` to `.gitignore`.

Particularly useful at the moment since we're now using flat config for linting and `vscode-eslint` still needs to be configured with `"eslint.experimental.useFlatConfig": true`.