### PR TITLE
feat: use `messageId` in tests

### DIFF
--- a/rule/templates/_test.js
+++ b/rule/templates/_test.js
@@ -27,7 +27,7 @@ ruleTester.run("<%= ruleId %>", rule, {
   invalid: [
     {
       code: "<%- invalidCode.replace(/"/g, '\\"') %>",
-      errors: [{ message: "Fill me in.", type: "Me too" }],
+      errors: [{ messageId: "Fill me in.", type: "Me too" }],
     },
   ],
 });


### PR DESCRIPTION
Since the lint config (`eslint-plugin-eslint-plugin` in particular) is set to enforce the use of messageId's in rules, I think it makes more sense for the test example to use `messageId` instead of `message`. 