### PR TITLE
feat: add `"files"` to generated `package.json`

### DIFF
--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -10,6 +10,9 @@
   "author": "<%- userName.replace(/"/g, '\\"') %>",
   "main": "./lib/index.js",
   "exports": "./lib/index.js",
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "lint": "npm-run-all \"lint:*\"",
     "lint:eslint-docs": "npm-run-all \"update:eslint-docs -- --check\"",


### PR DESCRIPTION
Adds `"files": [ "lib" ]` to the generated `package.json`.

To avoid lint errors:

```
C:\projects\tmp\tmp\eslint.config.mjs
   1:22  error  "@eslint/js" is not published                   n/no-unpublished-import
   2:24  error  "eslint-plugin-n" is not published              n/no-unpublished-import
   3:26  error  "eslint-plugin-eslint-plugin" is not published  n/no-unpublished-import
```

And I believe the plugin author would anyway have to add it before publishing.