### PR TITLE
fix: convert README template usage to flat

### DIFF
--- a/plugin/templates/_README.md
+++ b/plugin/templates/_README.md
@@ -18,23 +18,23 @@ npm install eslint-plugin-<%= pluginId %> --save-dev
 
 ## Usage
 
-Add `<%= pluginId %>` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
+Add `<%= pluginId %>` to the `plugins` key of your [configuration file](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file). You can omit the `eslint-plugin-` prefix:
 
-```json
+```js
 {
-    "plugins": [
+    plugins: {
         "<%= pluginId %>"
-    ]
+    }
 }
 ```
 
 <% if (hasRules) { %>
-Then configure the rules you want to use under the rules section.
+Then configure the rules you want to use under the `rules` key.
 
-```json
+```js
 {
-    "rules": {
-        "<%= pluginId %>/rule-name": 2
+    rules: {
+        "<%= pluginId %>/rule-name": "warn"
     }
 }
 ```

--- a/plugin/templates/_README.md
+++ b/plugin/templates/_README.md
@@ -18,25 +18,36 @@ npm install eslint-plugin-<%= pluginId %> --save-dev
 
 ## Usage
 
-Add `<%= pluginId %>` to the `plugins` key of your [configuration file](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file):
+In your [configuration file](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file), import the plugin `eslint-plugin-<%= pluginId %>` and add `<%= pluginId %>` to the `plugins` key:
 
 ```js
-{
-    plugins: {
-        "<%= pluginId %>"
+import <%= pluginId %> from "eslint-plugin-<%= pluginId %>";
+
+export default [
+    {
+        plugins: {
+            <%= pluginId %>
+        }
     }
-}
+];
 ```
 
 <% if (hasRules) { %>
 Then configure the rules you want to use under the `rules` key.
 
 ```js
-{
-    rules: {
-        "<%= pluginId %>/rule-name": "warn"
+import <%= pluginId %> from "eslint-plugin-<%= pluginId %>";
+
+export default [
+    {
+        plugins: {
+            <%= pluginId %>
+        },
+        rules: {
+            "<%= pluginId %>/rule-name": "warn"
+        }
     }
-}
+];
 ```
 
 <% } %>

--- a/plugin/templates/_README.md
+++ b/plugin/templates/_README.md
@@ -18,7 +18,7 @@ npm install eslint-plugin-<%= pluginId %> --save-dev
 
 ## Usage
 
-Add `<%= pluginId %>` to the `plugins` key of your [configuration file](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file). You can omit the `eslint-plugin-` prefix:
+Add `<%= pluginId %>` to the `plugins` key of your [configuration file](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file):
 
 ```js
 {

--- a/tests/plugin/index.js
+++ b/tests/plugin/index.js
@@ -57,7 +57,7 @@ describe("ESLint Plugin Generator", () => {
             assert.fileContent("README.md", "# eslint-plugin-foo-bar");
             assert.fileContent("README.md", "Next, install `eslint-plugin-foo-bar`:");
             assert.fileContent("README.md", "npm install eslint-plugin-foo-bar --save-dev");
-            assert.fileContent("README.md", "Add `foo-bar` to the `plugins` key");
+            assert.fileContent("README.md", "add `foo-bar` to the `plugins` key");
 
             assert.noFileContent("README.md", "Then configure the rules you want to use under the `rules` key.");
         });

--- a/tests/plugin/index.js
+++ b/tests/plugin/index.js
@@ -57,9 +57,9 @@ describe("ESLint Plugin Generator", () => {
             assert.fileContent("README.md", "# eslint-plugin-foo-bar");
             assert.fileContent("README.md", "Next, install `eslint-plugin-foo-bar`:");
             assert.fileContent("README.md", "npm install eslint-plugin-foo-bar --save-dev");
-            assert.fileContent("README.md", "Add `foo-bar` to the plugins section");
+            assert.fileContent("README.md", "Add `foo-bar` to the `plugins` key");
 
-            assert.noFileContent("README.md", "Then configure the rules you want to use under the rules section.");
+            assert.noFileContent("README.md", "Then configure the rules you want to use under the `rules` key.");
         });
 
         it("has correct lib/index.js", () => {
@@ -102,7 +102,7 @@ describe("ESLint Plugin Generator", () => {
         });
 
         it("has correct README.md", () => {
-            assert.fileContent("README.md", "\"foo-bar/rule-name\": 2");
+            assert.fileContent("README.md", "\"foo-bar/rule-name\": \"warn\"");
         });
     });
 


### PR DESCRIPTION
- closes https://github.com/eslint/generator-eslint/issues/193

## Issue

- PR https://github.com/eslint/generator-eslint/pull/179 converted templates to ESLint `v9` omitting to update [plugin/templates/_README.md](https://github.com/eslint/generator-eslint/blob/main/plugin/templates/_README.md). A `README.md` document generated with `generator-eslint@5.1.0` incorrectly refers to configuring an `.eslintrc` configuration file instead of describing how to configure a [current configuration file](https://eslint.org/docs/latest/use/configure/configuration-files).

## Change

- The [plugin/templates/_README.md](https://github.com/eslint/generator-eslint/blob/main/plugin/templates/_README.md) `Usage` section is converted from legacy to flat configuration and aligned to the current [Configure Plugins](https://eslint.org/docs/latest/use/configure/plugins) ESLint `v9` documentation.

![image](https://github.com/user-attachments/assets/e70212b2-ba8b-44ff-9469-dae838110142)
