### PR TITLE
chore: use eslint-doc-generator v2 in plugin template

### DIFF
--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "eslint": "^9.0.0",
     "@eslint/js": "^9.0.0",
-    "eslint-doc-generator": "^1.0.0",
+    "eslint-doc-generator": "^2.0.0",
     "eslint-plugin-eslint-plugin": "^6.0.0",
     "eslint-plugin-n": "^17.0.0",
     "mocha": "^10.0.0",


### PR DESCRIPTION
https://github.com/bmish/eslint-doc-generator/releases/tag/v2.0.0

No major changes besides modernizing the requirements.