### PR TITLE
fix: update to mocha v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-release": "^3.2.2",
     "globals": "^15.11.0",
     "markdownlint-cli": "^0.31.1",
-    "mocha": "^10.7.3",
+    "mocha": "^11.0.0",
     "npm-run-all": "^4.1.5",
     "yeoman-assert": "^3.1.1",
     "yeoman-environment": "^4.4.3",

--- a/plugin/templates/_package.json
+++ b/plugin/templates/_package.json
@@ -29,7 +29,7 @@
     "eslint-doc-generator": "^2.0.0",
     "eslint-plugin-eslint-plugin": "^6.0.0",
     "eslint-plugin-n": "^17.0.0",
-    "mocha": "^10.0.0",
+    "mocha": "^11.0.0",
     "npm-run-all2": "^6.1.2"
   },
   "engines": {


### PR DESCRIPTION
Not really a fix but it is external-facing since the plugin template is updated.
* https://github.com/mochajs/mocha/releases/tag/v11.0.0

This will also enable us to trigger a release with:
* https://github.com/eslint/generator-eslint/pull/197