### PR TITLE
fix: update the `rule-tester` import in rule test template

### DIFF
--- a/rule/templates/_test.js
+++ b/rule/templates/_test.js
@@ -9,7 +9,7 @@
 //------------------------------------------------------------------------------
 
 const rule = require("../../../lib/rules/<%= ruleId %>"),<% if (target === "eslint") { %>
-  RuleTester = require("../../../lib/testers/rule-tester");
+  RuleTester = require("../../../lib/rule-tester");
 <% } else { %>
   RuleTester = require("eslint").RuleTester;
 <% } %>

--- a/tests/rule/index.js
+++ b/tests/rule/index.js
@@ -76,7 +76,7 @@ describe("ESLint Rule Generator", () => {
         });
 
         it("has correct rule test file contents", () => {
-            assert.fileContent("tests/lib/rules/no-unused-vars.js", "RuleTester = require(\"../../../lib/testers/rule-tester\");");
+            assert.fileContent("tests/lib/rules/no-unused-vars.js", "RuleTester = require(\"../../../lib/rule-tester\");");
         });
     });
 


### PR DESCRIPTION
I was trying to use this generator today for implementing a new rule in ESLint core, and ran across a bug where the import in the generator rule test file could not be resolved.

I realized the correct import is
```ts
require("../../../lib/rule-tester")
```

unlike what was generated (like the following)
```ts
require("../../../lib/testers/rule-tester")
```

In this PR, I have corrected the import so it reflects the latest tree structure of `eslint/eslint` and updated the corresponding tests to expect the new import.

I also tried to generate a new rule using my local version of `generator-eslint` and it seems to work well for me.

**Note:** I did not file an issue because the [guidelines](https://eslint.org/docs/latest/contribute/pull-requests#getting-started) suggest that bug fixes do not require one.