### PR TITLE
fix: remove deprecated `type` from generated tests

### DIFF
--- a/rule/templates/_test.js
+++ b/rule/templates/_test.js
@@ -27,7 +27,7 @@ ruleTester.run("<%= ruleId %>", rule, {
   invalid: [
     {
       code: "<%- invalidCode.replace(/"/g, '\\"') %>",
-      errors: [{ messageId: "Fill me in.", type: "Me too" }],
+      errors: [{ messageId: "Fill me in." }],
     },
   ],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Remove deprecated `type` usage from the generated rule test template to ensure compatibility with the upcoming v10 release.

#### What changes did you make? (Give an overview)

Removed the `type` property from the rule test template.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
