### PR TITLE
chore: replace `npm-run-all` with native script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   ],
   "repository": "eslint/generator-eslint",
   "scripts": {
-    "lint": "npm-run-all --continue-on-error --aggregate-output --parallel lint:*",
+    "lint": "npm run lint:js && npm run lint:docs",
     "lint:docs": "markdownlint \"**/*.md\"",
-    "lint:js": "eslint .",
+    "lint:js": "eslint",
     "test": "mocha --recursive tests"
   },
   "dependencies": {
@@ -37,7 +37,6 @@
     "globals": "^16.0.0",
     "markdownlint-cli": "^0.31.1",
     "mocha": "^11.0.0",
-    "npm-run-all": "^4.1.5",
     "yeoman-assert": "^3.1.1",
     "yeoman-environment": "^4.4.3",
     "yeoman-test": "^10.1.1"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR is a follow-up to https://github.com/eslint/js/pull/664

In this PR, I've replaced `npm-run-all` with a native script.

Since `npm-run-all` is only used in a single place and, according to https://github.com/eslint/generator-eslint/pull/215, is deprecated, removing this dev dependency would reduce maintenance overhead.

#### What changes did you make? (Give an overview)

In this PR, I've replaced `npm-run-all` with a native script.

#### Related Issues

Ref: https://github.com/eslint/js/pull/664, https://github.com/eslint/generator-eslint/pull/215

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A