### PR TITLE
fix: eslint config error when using defineConfig

### DIFF
--- a/plugin/templates/_eslint.config.mjs
+++ b/plugin/templates/_eslint.config.mjs
@@ -16,13 +16,13 @@ export default defineConfig([
         plugins: {
             n: pluginNode,
         },
-        extends: ["n/mixed-esm-and-cjs"],
+        extends: ["n/flat/mixed-esm-and-cjs"],
     },
     {
         name: "eslint/eslint-plugin",
         plugins: {
             "eslint-plugin": eslintPlugin,
         },
-        extends: ["eslint-plugin/recommended"],
+        extends: ["eslint-plugin/flat/recommended"],
     }
 ]);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?
when running `npx eslint .`, it output the errors:
```bash
Oops! Something went wrong! :(

ESLint: 9.37.0

TypeError: Plugin config "mixed-esm-and-cjs" not found in plugin "n".
    at findPluginConfig (/tmp/tmp.6CcU4BUgW5/node_modules/@eslint/config-helpers/dist/cjs/index.cjs:287:8)
    at /tmp/tmp.6CcU4BUgW5/node_modules/@eslint/config-helpers/dist/cjs/index.cjs:423:25
    at Array.map (<anonymous>)
    at processExtends (/tmp/tmp.6CcU4BUgW5/node_modules/@eslint/config-helpers/dist/cjs/index.cjs:421:36)
    at /tmp/tmp.6CcU4BUgW5/node_modules/@eslint/config-helpers/dist/cjs/index.cjs:497:38
    at Array.flatMap (<anonymous>)
    at processConfigList (/tmp/tmp.6CcU4BUgW5/node_modules/@eslint/config-helpers/dist/cjs/index.cjs:497:20)
    at defineConfig (/tmp/tmp.6CcU4BUgW5/node_modules/@eslint/config-helpers/dist/cjs/index.cjs:533:9)
    at file:///tmp/tmp.6CcU4BUgW5/eslint.config.mjs?mtime=1759647699530:6:16
    at ModuleJob.run (node:internal/modules/esm/module_job:345:25)
```

```bash
Oops! Something went wrong! :(

ESLint: 9.37.0


A config object has a "plugins" key defined as an array of strings. It looks something like this:

    {
        "plugins": ["eslint-plugin"]
    }

Flat config requires "plugins" to be an object, like this:

    {
        plugins: {
            eslint-plugin: pluginObject
        }
    }

Please see the following page for information on how to convert your config object into the correct format:
https://eslint.org/docs/latest/use/configure/migration-guide#importing-plugins-and-custom-parsers

If you're using a shareable config that you cannot rewrite in flat config format, then use the compatibility utility:
https://eslint.org/docs/latest/use/configure/migration-guide#using-eslintrc-configs-in-flat-config
```


fixes #227 

#### What changes did you make? (Give an overview)

* use the flat config directly, instead of guessing the config format.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

```js
const config = {plugins: ["eslint-plugin"]};
```

this is wrongly seen as flat config; we might need to fix it in `@eslint/config-helper`.