### PR TITLE
ci: fix CI failure on `main` branch

### DIFF
--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -11,4 +11,4 @@ on:
 
 jobs:
     ci-package-manager:
-        uses: eslint/workflows/.github/workflows/ci-package-manager.yml@main
+        uses: eslint/workflows/.github/workflows/ci-package-manager.yml@fix/ci-failure

--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
     ci-package-manager:
-        uses: eslint/workflows/.github/workflows/ci-package-manager.yml@fix/ci-failure
+        uses: eslint/workflows/.github/workflows/ci-package-manager.yml@main
         with:
             pnpm_allow_build_args: yo

--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -13,4 +13,4 @@ jobs:
     ci-package-manager:
         uses: eslint/workflows/.github/workflows/ci-package-manager.yml@fix/ci-failure
         with:
-            pnpm_approve_builds: yo
+            pnpm_allow_build: yo

--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -12,3 +12,5 @@ on:
 jobs:
     ci-package-manager:
         uses: eslint/workflows/.github/workflows/ci-package-manager.yml@fix/ci-failure
+        with:
+            pnpm_approve_builds: yo

--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -13,4 +13,4 @@ jobs:
     ci-package-manager:
         uses: eslint/workflows/.github/workflows/ci-package-manager.yml@fix/ci-failure
         with:
-            pnpm_config_allow_build: yo
+            pnpm_allow_build_args: yo

--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -13,4 +13,4 @@ jobs:
     ci-package-manager:
         uses: eslint/workflows/.github/workflows/ci-package-manager.yml@fix/ci-failure
         with:
-            pnpm_allow_build: yo
+            pnpm_config_allow_build: yo


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## What is the purpose of this pull request?

This PR fixes an issue where the `main` branch is failing.

https://github.com/eslint/generator-eslint/actions/runs/26748181155/job/78829075484
  
<img width="651" height="397" alt="image" src="https://github.com/user-attachments/assets/2554f11f-a789-4537-a5bf-bba705311e73" />

## What changes did you make? (Give an overview)

I’ve updated the `.github/workflows/ci-package-manager.yml` file to pass the `pnpm_allow_build_args` option so that `yo` can use the `postinstall` script when installing with PNPM.

The corresponding PR in https://github.com/eslint/workflows/pull/60 has already been merged, so this PR can be safely merged now.

## Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

Refs: https://github.com/eslint/workflows/pull/60, https://github.com/eslint/generator-eslint/actions/runs/26748181155/job/78829075484

## Is there anything you'd like reviewers to focus on?

- [x] This PR should be merged after https://github.com/eslint/workflows/pull/60 has been merged.
